### PR TITLE
Add assertions to document core invariants

### DIFF
--- a/src/main/java/silvermoon/Deadline.java
+++ b/src/main/java/silvermoon/Deadline.java
@@ -11,6 +11,7 @@ public class Deadline extends Task {
 
     public Deadline(String description, LocalDate by) {
         super(description);
+        assert by != null : "Deadline date must be non-null";
         this.by = by;
     }
 

--- a/src/main/java/silvermoon/Event.java
+++ b/src/main/java/silvermoon/Event.java
@@ -9,6 +9,8 @@ public class Event extends Task {
 
     public Event(String description, String from, String to) {
         super(description);
+        assert from != null && !from.isBlank() : "Event 'from' must be non-empty";
+        assert to != null && !to.isBlank()     : "Event 'to' must be non-empty";
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/silvermoon/Storage.java
+++ b/src/main/java/silvermoon/Storage.java
@@ -18,6 +18,7 @@ public class Storage {
     private final Path dataFile;
 
     public Storage(String fileName) {
+        assert fileName != null && !fileName.isBlank() : "fileName must not be blank";
         // Robust: if tests run from text-ui-test/, resolve to project root
         Path base = Paths.get(System.getProperty("user.dir"));
         if (base.getFileName() != null && base.getFileName().toString().equals("text-ui-test")) {
@@ -59,6 +60,7 @@ public class Storage {
         // T | 1 | description
         // D | 0 | description | by
         // E | 1 | description | from | to
+        assert line != null : "Line must not be null";
         String[] parts = line.split("\\s*\\|\\s*");
         if (parts.length < 3) return null;
         String type = parts[0];
@@ -88,6 +90,7 @@ public class Storage {
     }
 
     private String serialize(Task t) {
+        assert t != null : "Cannot serialize null task";
         String done = t.isDone ? "1" : "0";
         if (t instanceof ToDo) {
             return String.join(" | ", "T", done, t.description);

--- a/src/main/java/silvermoon/Task.java
+++ b/src/main/java/silvermoon/Task.java
@@ -5,6 +5,7 @@ public class Task {
     protected boolean isDone;
 
     public Task(String description) {
+        assert description != null && !description.isBlank() : "Task description must be non-empty";
         this.description = description;
         this.isDone = false;
     }

--- a/src/main/java/silvermoon/TaskList.java
+++ b/src/main/java/silvermoon/TaskList.java
@@ -20,6 +20,7 @@ public class TaskList {
      * @param initial initial tasks to populate the list with
      */
     public TaskList(List<Task> initial) {
+        assert initial != null : "Initial list must not be null";
         this.tasks = new ArrayList<>(initial);
     }
 
@@ -29,6 +30,7 @@ public class TaskList {
      * @param task the task to add
      */
     public void add(Task task) {
+        assert task != null : "Task must not be null";
         tasks.add(task);
     }
 
@@ -40,6 +42,7 @@ public class TaskList {
      * @throws IndexOutOfBoundsException if {@code idx} is out of range
      */
     public Task removeAt(int idx) {
+        assert idx >= 0 && idx < tasks.size() : "Index out of bounds";
         return tasks.remove(idx);
     }
 
@@ -51,6 +54,7 @@ public class TaskList {
      * @throws IndexOutOfBoundsException if {@code idx} is out of range
      */
     public Task get(int idx) {
+        assert idx >= 0 && idx < tasks.size() : "Index out of bounds";
         return tasks.get(idx);
     }
 


### PR DESCRIPTION
This change introduces Java 'assert' statements across core classes to codify programmer assumptions and show logic errors during development.

Why:
- Some invariants (e.g., non-null descriptions/dates, valid indices) should never be violated if the code is correct.
- Asserts document these assumptions and fail fast when broken.

What:
- Task/Deadline/Event: assert non-null/ non-blank constructor args.
- TaskList: assert non-null list; validate indices and non-null tasks.
- Storage: assert non-blank file name; non-null serialise/parse inputs.